### PR TITLE
HID: ft260: enable gpio based on i2c, uart and wakeup mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ KBUILD ?= /lib/modules/$(KRELEASE)/build
 obj-m += hid-ft260.o
 
 all:
-	$(MAKE) -C $(KBUILD) M=$(PWD) modules
+	$(MAKE) -C $(KBUILD) M=$(shell pwd) modules
 
 clean:
-	$(MAKE) -C $(KBUILD) M=$(PWD) clean
+	$(MAKE) -C $(KBUILD) M=$(shell pwd) clean


### PR DESCRIPTION
 - feat: Add enable_wake_int attribute
 - feat: replace dummy handler for uart_mode attribute
 - feat: replace dummy handler for i2c_enable attribute
 - feat: separate i2c and uart probing
 - feat: Add uio device for uart interface interupt
 - fix: allow several gpiochip for several ft260